### PR TITLE
Fix doc from cluster_spec datasource to cluster_specs datasource

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -114,8 +114,8 @@ Optional:
 
 Required:
 
-- `node_quantity` (Number) The number of nodes in the cluster. You can get the minimum and step of a node quantity from the [tidbcloud_cluster_spec datasource](../data-sources/cluster_spec.md).
-- `node_size` (String) The size of the TiDB component in the cluster, You can get the available node size of each region from the [tidbcloud_cluster_spec datasource](../data-sources/cluster_spec.md).
+- `node_quantity` (Number) The number of nodes in the cluster. You can get the minimum and step of a node quantity from the [tidbcloud_cluster_specs datasource](../data-sources/cluster_specs.md).
+- `node_size` (String) The size of the TiDB component in the cluster, You can get the available node size of each region from the [tidbcloud_cluster_specs datasource](../data-sources/cluster_specs.md).
   - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.
   - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.
   - Can not modify node_size of an existing cluster.

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -211,14 +211,14 @@ func (t clusterResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 								Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 									"node_size": {
 										Required: true,
-										MarkdownDescription: "The size of the TiDB component in the cluster, You can get the available node size of each region from the [tidbcloud_cluster_spec datasource](../data-sources/cluster_spec.md).\n" +
+										MarkdownDescription: "The size of the TiDB component in the cluster, You can get the available node size of each region from the [tidbcloud_cluster_specs datasource](../data-sources/cluster_specs.md).\n" +
 											"  - If the vCPUs of TiDB or TiKV component is 2 or 4, then their vCPUs need to be the same.\n" +
 											"  - If the vCPUs of TiDB or TiKV component is 2 or 4, then the cluster does not support TiFlash.\n" +
 											"  - Can not modify node_size of an existing cluster.",
 										Type: types.StringType,
 									},
 									"node_quantity": {
-										MarkdownDescription: "The number of nodes in the cluster. You can get the minimum and step of a node quantity from the [tidbcloud_cluster_spec datasource](../data-sources/cluster_spec.md).",
+										MarkdownDescription: "The number of nodes in the cluster. You can get the minimum and step of a node quantity from the [tidbcloud_cluster_specs datasource](../data-sources/cluster_specs.md).",
 										Required:            true,
 										Type:                types.Int64Type,
 									},

--- a/internal/provider/cluster_specs_data_source.go
+++ b/internal/provider/cluster_specs_data_source.go
@@ -232,7 +232,7 @@ func (d clusterSpecsDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	tflog.Trace(ctx, "read cluster_spec data source")
+	tflog.Trace(ctx, "read cluster_specs data source")
 	spec, err := d.provider.client.GetSpecifications()
 	if err != nil {
 		resp.Diagnostics.AddError("Read Error", fmt.Sprintf("Unable to call read specifications, got error: %s", err))


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix cluster_spec datasource to cluster_specs datasource

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

- Possible to add a test?
- Don't forget to run `go generate` if you modify `examples`.
