### PR TITLE
Fix duplicate CIDR error in cluster creating

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	clusterApi "github.com/c4pt0r/go-tidbcloud-sdk-v1/client/cluster"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"strings"
 )
 
 const dev = "DEVELOPER"
@@ -468,8 +469,9 @@ func buildCreateClusterBody(data clusterResourceData) clusterApi.CreateClusterBo
 	if data.Config.IPAccessList != nil {
 		var IPAccessList []*clusterApi.CreateClusterParamsBodyConfigIPAccessListItems0
 		for _, key := range data.Config.IPAccessList {
+			cidr := key.CIDR
 			IPAccessList = append(IPAccessList, &clusterApi.CreateClusterParamsBodyConfigIPAccessListItems0{
-				Cidr:        &key.CIDR,
+				Cidr:        &cidr,
 				Description: key.Description,
 			})
 		}

--- a/internal/provider/restore_resource.go
+++ b/internal/provider/restore_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	restoreApi "github.com/c4pt0r/go-tidbcloud-sdk-v1/client/restore"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -319,8 +320,9 @@ func buildCreateRestoreTaskBody(data restoreResourceData) restoreApi.CreateResto
 	if data.Config.IPAccessList != nil {
 		var IPAccessList []*restoreApi.CreateRestoreTaskParamsBodyConfigIPAccessListItems0
 		for _, key := range data.Config.IPAccessList {
+			cidr := key.CIDR
 			IPAccessList = append(IPAccessList, &restoreApi.CreateRestoreTaskParamsBodyConfigIPAccessListItems0{
-				Cidr:        &key.CIDR,
+				Cidr:        &cidr,
 				Description: key.Description,
 			})
 		}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
#69 

### What is changed and how it works?

Fixed the improper variable reference to the variable `key` in the loop. This was causing unexpected duplicate value issue, and the fix ensures that the expected value is appended in the slice.

### Check List <!--REMOVE the items that are not applicable-->

- Possible to add a test?: No
- Don't forget to run `go generate` if you modify `examples`.: No
