### PR TITLE
Fix TiDB Serverless show paused

### DIFF
--- a/internal/provider/plan_modify.go
+++ b/internal/provider/plan_modify.go
@@ -36,7 +36,16 @@ func (m clusterResourceStatusModifier) PlanModifyObject(ctx context.Context, req
 	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	// Does not apply to cluster_status attribute
+
+	// Apply state value if cluster is a serverless cluster
+	var data clusterResourceData
+	req.State.Get(ctx, &data)
+	if data.ClusterType == dev {
+		resp.PlanValue = req.StateValue
+		return
+	}
+
+	// Does not apply to cluster_status attribute for dedicated
 	attributes := req.StateValue.Attributes()
 	attributes["cluster_status"] = types.StringUnknown()
 	newStateValue, diag := basetypes.NewObjectValue(req.StateValue.AttributeTypes(ctx), attributes)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

1. Fix paused will be shown in TiDB Serverless. 
2. Fix change occurs when executing `terraform plan` in TiDB Serverless


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

- Possible to add a test?
- Don't forget to run `go generate` if you modify `examples`.
