### PR TITLE
fix bug: can not pause cluster because storage type is unknown

### DIFF
--- a/internal/provider/dedicated_cluster_resource.go
+++ b/internal/provider/dedicated_cluster_resource.go
@@ -361,6 +361,9 @@ func (r *dedicatedClusterResource) Schema(_ context.Context, _ resource.SchemaRe
 							"- Plus: Data disk: io2; Raft log disk: none.",
 						Optional: true,
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"node_spec_display_name": schema.StringAttribute{
 						MarkdownDescription: "The display name of the node spec.",
@@ -396,6 +399,9 @@ func (r *dedicatedClusterResource) Schema(_ context.Context, _ resource.SchemaRe
 							"- Plus: Data disk: io2; Raft log disk: none.",
 						Optional: true,
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"node_spec_display_name": schema.StringAttribute{
 						MarkdownDescription: "The display name of the node spec.",


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

- Possible to add a test?
- Don't forget to run `go generate` if you modify `examples`.
