### PR TITLE
Fix zero auto scaling state handling

### DIFF
--- a/internal/provider/serverless_cluster_resource.go
+++ b/internal/provider/serverless_cluster_resource.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -451,12 +452,12 @@ func (r serverlessClusterResource) Create(ctx context.Context, req resource.Crea
 
 func (r serverlessClusterResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// get data from state
-	var clusterId string
-
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("cluster_id"), &clusterId)...)
+	var data serverlessClusterResourceData
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	clusterId := data.ClusterId.ValueString()
 	tflog.Debug(ctx, fmt.Sprintf("read serverless_cluster_resource cluster_id: %s", clusterId))
 
 	// call read api
@@ -466,7 +467,6 @@ func (r serverlessClusterResource) Read(ctx context.Context, req resource.ReadRe
 		tflog.Error(ctx, fmt.Sprintf("Unable to call GetCluster, error: %s", err))
 		return
 	}
-	var data serverlessClusterResourceData
 	err = refreshServerlessClusterResourceData(ctx, cluster, &data)
 	if err != nil {
 		resp.Diagnostics.AddError("Refresh Error", fmt.Sprintf("Unable to refresh serverless cluster resource data, got error: %s", err))
@@ -543,12 +543,17 @@ func (r serverlessClusterResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	if IsKnown(plan.SpendingLimit) {
-		if IsKnown(plan.AutoScaling) || IsKnown(state.AutoScaling) {
+		stateHasAutoScaling, diags := hasEffectiveAutoScaling(ctx, state.AutoScaling)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if IsKnown(plan.AutoScaling) || stateHasAutoScaling {
 			resp.Diagnostics.AddError("Update Error", "Cannot set both spending limit and capacity for serverless cluster")
 			return
 		}
 		var planLimit spendingLimit
-		diags := plan.SpendingLimit.As(ctx, &planLimit, basetypes.ObjectAsOptions{})
+		diags = plan.SpendingLimit.As(ctx, &planLimit, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
@@ -642,14 +647,14 @@ func (r serverlessClusterResource) Update(ctx context.Context, req resource.Upda
 		tflog.Error(ctx, fmt.Sprintf("Unable to call GetCluster, error: %s", err))
 		return
 	}
-	err = refreshServerlessClusterResourceData(ctx, cluster, &state)
+	err = refreshServerlessClusterResourceData(ctx, cluster, &plan)
 	if err != nil {
 		resp.Diagnostics.AddError("Refresh Error", fmt.Sprintf("Unable to refresh serverless cluster resource data, got error: %s", err))
 		return
 	}
 
 	// save into the Terraform state.
-	diags = resp.State.Set(ctx, &state)
+	diags = resp.State.Set(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 }
 
@@ -764,7 +769,7 @@ func refreshServerlessClusterResourceData(ctx context.Context, resp *clusterV1be
 		data.SpendingLimit = types.ObjectNull(spendingLimitAttrTypes)
 	}
 
-	if resp.AutoScaling != nil {
+	if hasAPIAutoScaling(resp.AutoScaling) || (resp.AutoScaling != nil && IsKnown(data.AutoScaling)) {
 		as := autoScaling{
 			MinRCU: types.Int64Value(*resp.AutoScaling.MinRcu),
 			MaxRCU: types.Int64Value(*resp.AutoScaling.MaxRcu),
@@ -823,6 +828,31 @@ func refreshServerlessClusterResourceData(ctx context.Context, resp *clusterV1be
 	data.Labels = labels
 	data.Annotations = annotations
 	return nil
+}
+
+func hasEffectiveAutoScaling(ctx context.Context, value types.Object) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if !IsKnown(value) {
+		return false, diags
+	}
+
+	var as autoScaling
+	diags = value.As(ctx, &as, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		return false, diags
+	}
+	return !isZeroAutoScaling(as.MinRCU.ValueInt64(), as.MaxRCU.ValueInt64()), diags
+}
+
+func hasAPIAutoScaling(as *clusterV1beta1.V1beta1ClusterAutoScaling) bool {
+	if as == nil || as.MinRcu == nil || as.MaxRcu == nil {
+		return false
+	}
+	return !isZeroAutoScaling(*as.MinRcu, *as.MaxRcu)
+}
+
+func isZeroAutoScaling(minRCU, maxRCU int64) bool {
+	return minRCU == 0 && maxRCU == 0
 }
 
 func WaitServerlessClusterReady(ctx context.Context, timeout time.Duration, interval time.Duration, clusterId string,

--- a/internal/provider/serverless_cluster_resource_test.go
+++ b/internal/provider/serverless_cluster_resource_test.go
@@ -1,10 +1,13 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	mockClient "github.com/tidbcloud/terraform-provider-tidbcloud/mock"
 	"github.com/tidbcloud/terraform-provider-tidbcloud/tidbcloud"
@@ -87,6 +90,9 @@ func testServerlessClusterResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(serverlessClusterResourceName, "cluster_id"),
 					resource.TestCheckResourceAttr(serverlessClusterResourceName, "display_name", "test-tf"),
 					resource.TestCheckResourceAttr(serverlessClusterResourceName, "region.name", "regions/aws-us-east-1"),
+					resource.TestCheckResourceAttr(serverlessClusterResourceName, "spending_limit.monthly", "0"),
+					resource.TestCheckNoResourceAttr(serverlessClusterResourceName, "auto_scaling.min_rcu"),
+					resource.TestCheckNoResourceAttr(serverlessClusterResourceName, "auto_scaling.max_rcu"),
 				),
 			},
 			// // Update correctly
@@ -100,6 +106,100 @@ func testServerlessClusterResource(t *testing.T) {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+func TestRefreshServerlessClusterResourceDataNormalizesZeroAutoScaling(t *testing.T) {
+	clusterId := "cluster_id"
+	regionName := "regions/aws-us-east-1"
+	displayName := "test-tf"
+
+	getClusterResp := clusterV1beta1.TidbCloudOpenApiserverlessv1beta1Cluster{}
+	err := getClusterResp.UnmarshalJSON([]byte(testUTTidbCloudOpenApiserverlessv1beta1Cluster(clusterId, regionName, displayName, string(clusterV1beta1.COMMONV1BETA1CLUSTERSTATE_ACTIVE))))
+	if err != nil {
+		t.Fatalf("failed to unmarshal cluster fixture: %v", err)
+	}
+
+	var data serverlessClusterResourceData
+	err = refreshServerlessClusterResourceData(context.Background(), &getClusterResp, &data)
+	if err != nil {
+		t.Fatalf("failed to refresh serverless cluster data: %v", err)
+	}
+	if !data.AutoScaling.IsNull() {
+		t.Fatalf("expected zero auto scaling response to be normalized to null, got %#v", data.AutoScaling)
+	}
+}
+
+func TestRefreshServerlessClusterResourceDataPreservesExplicitZeroAutoScaling(t *testing.T) {
+	clusterId := "cluster_id"
+	regionName := "regions/aws-us-east-1"
+	displayName := "test-tf"
+
+	getClusterResp := clusterV1beta1.TidbCloudOpenApiserverlessv1beta1Cluster{}
+	err := getClusterResp.UnmarshalJSON([]byte(testUTTidbCloudOpenApiserverlessv1beta1Cluster(clusterId, regionName, displayName, string(clusterV1beta1.COMMONV1BETA1CLUSTERSTATE_ACTIVE))))
+	if err != nil {
+		t.Fatalf("failed to unmarshal cluster fixture: %v", err)
+	}
+
+	ctx := context.Background()
+	data := serverlessClusterResourceData{
+		AutoScaling: mustAutoScalingObject(t, ctx, 0, 0),
+	}
+
+	err = refreshServerlessClusterResourceData(ctx, &getClusterResp, &data)
+	if err != nil {
+		t.Fatalf("failed to refresh serverless cluster data: %v", err)
+	}
+	if data.AutoScaling.IsNull() {
+		t.Fatal("expected explicit zero auto scaling to be preserved")
+	}
+
+	var refreshed autoScaling
+	diags := data.AutoScaling.As(ctx, &refreshed, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		t.Fatalf("failed to decode refreshed auto scaling: %v", diags)
+	}
+	if refreshed.MinRCU.ValueInt64() != 0 || refreshed.MaxRCU.ValueInt64() != 0 {
+		t.Fatalf("expected zero auto scaling, got min=%d max=%d", refreshed.MinRCU.ValueInt64(), refreshed.MaxRCU.ValueInt64())
+	}
+}
+
+func TestRefreshServerlessClusterResourceDataPreservesPlannedZeroAutoScaling(t *testing.T) {
+	clusterId := "cluster_id"
+	regionName := "regions/aws-us-east-1"
+	displayName := "test-tf"
+
+	getClusterResp := clusterV1beta1.TidbCloudOpenApiserverlessv1beta1Cluster{}
+	err := getClusterResp.UnmarshalJSON([]byte(testUTTidbCloudOpenApiserverlessv1beta1Cluster(clusterId, regionName, displayName, string(clusterV1beta1.COMMONV1BETA1CLUSTERSTATE_ACTIVE))))
+	if err != nil {
+		t.Fatalf("failed to unmarshal cluster fixture: %v", err)
+	}
+
+	ctx := context.Background()
+	plan := serverlessClusterResourceData{
+		AutoScaling: mustAutoScalingObject(t, ctx, 0, 0),
+	}
+
+	err = refreshServerlessClusterResourceData(ctx, &getClusterResp, &plan)
+	if err != nil {
+		t.Fatalf("failed to refresh serverless cluster data: %v", err)
+	}
+	if plan.AutoScaling.IsNull() {
+		t.Fatal("expected planned zero auto scaling to be preserved")
+	}
+}
+
+func mustAutoScalingObject(t *testing.T, ctx context.Context, minRCU, maxRCU int64) types.Object {
+	t.Helper()
+
+	as := autoScaling{
+		MinRCU: types.Int64Value(minRCU),
+		MaxRCU: types.Int64Value(maxRCU),
+	}
+	value, diags := types.ObjectValueFrom(ctx, autoScalingAttrTypes, as)
+	if diags.HasError() {
+		t.Fatalf("failed to build auto scaling object: %v", diags)
+	}
+	return value
 }
 
 func testAccServerlessClusterResourceConfig() string {
@@ -160,6 +260,10 @@ func testUTTidbCloudOpenApiserverlessv1beta1Cluster(clusterId, regionName, displ
     },
     "spendingLimit": {
         "monthly": 0
+    },
+    "autoScaling": {
+        "minRcu": 0,
+        "maxRcu": 0
     },
     "automatedBackupPolicy": {
         "startTime": "07:00",


### PR DESCRIPTION
### What problem does this PR solve? 

Fixes https://github.com/tidbcloud/terraform-provider-tidbcloud/issues/249

`tidbcloud_serverless_cluster` without setting `auto_scaling` (default), the provider returns auto_scaling = {min_rcu = 0, max_rcu = 0} in state, causing Provider produced inconsistent result after apply.

### What is changed and how it works?

 The provider now normalizes API-returned zero autoScaling values to null only when auto_scaling is not explicitly configured. Explicit auto_scaling={0,0} remains preserved in state and is sent to the API as user intent.

### Check List 

- Possible to add a test? - yes
- Don't forget to run `go generate` if you modify `examples`.  - no change in `examples`