### PR TITLE
ci: pre-install Terraform CLI in unit tests to fix expired OpenPGP key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,4 +60,5 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@v4
       - run: go test -v -cover ./internal/provider/


### PR DESCRIPTION
## Summary

- The `ut` job in `test.yml` was missing `hashicorp/setup-terraform`, causing `terraform-plugin-testing` to auto-download Terraform CLI at runtime
- HashiCorp's OpenPGP signing key has expired, so the auto-download fails with `unable to verify checksums signature: openpgp: key expired`, breaking all unit tests
- Add `hashicorp/setup-terraform@v4` to pre-install Terraform CLI, consistent with the `generate` job