### PR TITLE
fix: prevent perpetual plan diff on serverless cluster computed attrributes

### DIFF
--- a/internal/provider/serverless_cluster_resource.go
+++ b/internal/provider/serverless_cluster_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -350,6 +351,9 @@ func (r *serverlessClusterResource) Schema(_ context.Context, _ resource.SchemaR
 			"version": schema.StringAttribute{
 				MarkdownDescription: "The version of the cluster.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_by": schema.StringAttribute{
 				MarkdownDescription: "The email of the creator of the cluster.",
@@ -368,6 +372,9 @@ func (r *serverlessClusterResource) Schema(_ context.Context, _ resource.SchemaR
 			"update_time": schema.StringAttribute{
 				MarkdownDescription: "The time the cluster was last updated.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"user_prefix": schema.StringAttribute{
 				MarkdownDescription: "The unique prefix in SQL user name.",
@@ -379,16 +386,25 @@ func (r *serverlessClusterResource) Schema(_ context.Context, _ resource.SchemaR
 			"state": schema.StringAttribute{
 				MarkdownDescription: "The state of the cluster.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"labels": schema.MapAttribute{
 				MarkdownDescription: "The labels of the cluster.",
 				Computed:            true,
 				ElementType:         types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"annotations": schema.MapAttribute{
 				MarkdownDescription: "The annotations of the cluster.",
 				Computed:            true,
 				ElementType:         types.StringType,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

After creating Starter cluster, `terraform plan` always produces in-place update. Actually it changes noting but `terraform plan` returns 2 and cause confusion.

```
Terraform will perform the following actions:

  # tidbcloud_serverless_cluster.starter will be updated in-place
  ~ resource "tidbcloud_serverless_cluster" "starter" {
      ~ annotations             = {
          - "tidb.cloud/available-features" = "DISABLE_PUBLIC_LB,DELEGATE_USER"
          - "tidb.cloud/has-set-password"   = "false"
        } -> (known after apply)
      ~ labels                  = {
          - "tidb.cloud/organization" = "<org id>"
          - "tidb.cloud/project"      = "<project id>"
        } -> (known after apply)
      ~ state                   = "ACTIVE" -> (known after apply)
      ~ update_time             = "2026-07-03T05:22:36Z" -> (known after apply)
      ~ version                 = "v8.5.3" -> (known after apply)
        # (11 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### What is changed and how it works?

Add UseStateForUnknown plan modifiers to the computed-only attributes version, update_time, state, labels, and annotations. Without them these attributes were planned as "(known after apply)" on every no-op plan, producing a spurious in-place update. Matches the existing treatment of other computed attributes (create_time, cluster_id, etc.).

Ref: https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification#common-use-case-attribute-plan-modifiers
